### PR TITLE
Use #find_one to test #exists?

### DIFF
--- a/lib/minidoc/finders.rb
+++ b/lib/minidoc/finders.rb
@@ -19,7 +19,7 @@ module Minidoc::Finders
     end
 
     def exists?(selector = {})
-      count(selector) > 0
+      find_one(selector).present?
     end
 
     def find(id_or_selector, options = {})


### PR DESCRIPTION
In many cases (such as with a non-indexed selector), `#find_one` can be
notably faster than `#count`. In indexed cases, they should be about the
same.

cc @codeclimate/review