### PR TITLE
Fix remaining brynary references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Code Climate](https://codeclimate.com/github/brynary/minidoc.svg)](https://codeclimate.com/github/brynary/minidoc)
-[![Build Status](https://travis-ci.org/brynary/minidoc.svg)](https://travis-ci.org/brynary/minidoc)
+[![Build Status](https://travis-ci.org/codeclimate/minidoc.svg)](https://travis-ci.org/codeclimate/minidoc)
 
 # Minidoc
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Code Climate](https://codeclimate.com/github/brynary/minidoc.svg)](https://codeclimate.com/github/brynary/minidoc)
+[![Code Climate](https://codeclimate.com/github/codeclimate/minidoc/badges/gpa.svg)](https://codeclimate.com/github/codeclimate/minidoc)
 [![Build Status](https://travis-ci.org/codeclimate/minidoc.svg)](https://travis-ci.org/codeclimate/minidoc)
 
 # Minidoc

--- a/minidoc.gemspec
+++ b/minidoc.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Bryan Helmkamp"]
   spec.email         = ["bryan@brynary.com"]
   spec.summary       = %q{Lightweight wrapper for MongoDB documents}
-  spec.homepage      = "https://github.com/brynary/minidoc"
+  spec.homepage      = "https://github.com/codeclimate/minidoc"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
I noticed that the README badge image tag is currently broken. The
gemspec change will become relevant when we release this on rubygems.