### PR TITLE
Use $set to only alter specified fields in Mongo document on update

### DIFF
--- a/lib/minidoc.rb
+++ b/lib/minidoc.rb
@@ -234,7 +234,7 @@ private
   end
 
   def update
-    self.class.collection.update({ _id: id }, attributes)
+    self.class.collection.update({ _id: id }, { "$set" => attributes.except(:_id) })
   end
 
   if ActiveSupport.respond_to?(:run_load_hooks)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,7 +7,15 @@ I18n.enforce_available_locales = false
 I18n.load_path << File.expand_path("../locale/en.yml", __FILE__)
 
 class User < Minidoc
+  self.collection_name = "users"
+
   attribute :name, String
+  attribute :age, Integer
+end
+
+class SecondUser < Minidoc
+  self.collection_name = "users"
+
   attribute :age, Integer
 end
 

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -72,6 +72,21 @@ class PersistenceTest < Minidoc::TestCase
     assert_equal "Noah", user.reload.name
   end
 
+  def test_update_same_collection
+    user = User.create(name: "Bryan", age: 20)
+    user.name = "Noah"
+    assert_equal "Noah", user.name
+    user.save
+    assert_equal "Noah", user.reload.name
+    second_user = SecondUser.find_one(age: 20)
+    assert_equal second_user.id, user.id
+    second_user.age = 21
+    assert_equal 21, second_user.age
+    second_user.save
+    assert_equal 21, second_user.reload.age
+    assert_equal "Noah", user.reload.name
+  end
+
   def test_destroy
     user = User.create(name: "Bryan")
     assert_equal false, user.destroyed?


### PR DESCRIPTION
This addresses the issue @pbrisbin raised in codeclimate/app#2919, where calling `Minidoc#update` overwrites the entire Mongo document in lieu of only updating fields specified by the model.

cc @codeclimate/review 