### PR TITLE
Infer association class name when not provided

### DIFF
--- a/lib/minidoc/associations.rb
+++ b/lib/minidoc/associations.rb
@@ -9,6 +9,8 @@ module Minidoc::Associations
     end
 
     def belongs_to(association_name, options = {})
+      options[:class_name] ||= association_name.to_s.camelize
+
       association_name = association_name.to_sym
       associations[association_name] = options
 

--- a/lib/minidoc/associations.rb
+++ b/lib/minidoc/associations.rb
@@ -9,7 +9,7 @@ module Minidoc::Associations
     end
 
     def belongs_to(association_name, options = {})
-      options[:class_name] ||= association_name.to_s.camelize
+      options[:class_name] ||= "#{self.parent.name}::#{association_name.to_s.camelize}"
 
       association_name = association_name.to_sym
       associations[association_name] = options

--- a/test/belongs_to_test.rb
+++ b/test/belongs_to_test.rb
@@ -6,6 +6,11 @@ class BelongsToTest < Minidoc::TestCase
     belongs_to :owner, class_name: "User"
   end
 
+  class Dog < Minidoc
+    include Minidoc::Associations
+    belongs_to :user
+  end
+
   class User < ::User
   end
 
@@ -45,5 +50,14 @@ class BelongsToTest < Minidoc::TestCase
     assert_equal "Bryan", cat.owner.name # doesn't change
     cat.owner_id = user.id
     assert_equal "Noah", cat.owner.name # changes
+  end
+
+  def test_inferred_class_name
+    assert_nil Dog.new.user
+    user = User.create
+    sam = Dog.new(user_id: user.id)
+    assert_equal user.id, sam.user.id
+    sam.save
+    assert_equal user.id, sam.user.id
   end
 end

--- a/test/belongs_to_test.rb
+++ b/test/belongs_to_test.rb
@@ -6,12 +6,22 @@ class BelongsToTest < Minidoc::TestCase
     belongs_to :owner, class_name: "User"
   end
 
-  class Dog < Minidoc
+  class ::Dog < Minidoc
     include Minidoc::Associations
     belongs_to :user
   end
 
   class User < ::User
+  end
+
+  module Animal
+    class Armadillo < Minidoc
+      include Minidoc::Associations
+      belongs_to :predator
+    end
+
+    class Predator < Minidoc
+    end
   end
 
   def test_loading
@@ -52,12 +62,21 @@ class BelongsToTest < Minidoc::TestCase
     assert_equal "Noah", cat.owner.name # changes
   end
 
-  def test_inferred_class_name
+  def test_top_level_inferred_class_name
     assert_nil Dog.new.user
     user = User.create
     sam = Dog.new(user_id: user.id)
     assert_equal user.id, sam.user.id
     sam.save
     assert_equal user.id, sam.user.id
+  end
+
+  def test_nested_inferred_class_name
+    assert_nil Animal::Armadillo.new.predator
+    predator = Animal::Predator.create
+    arnie = Animal::Armadillo.new(predator_id: predator.id)
+    assert_equal predator.id, arnie.predator.id
+    arnie.save
+    assert_equal predator.id, arnie.predator.id
   end
 end


### PR DESCRIPTION
Defining setters & getters blindly without knowing if a class name was
provided doesn't seem great. Needing to provide a class name explicitly
when in many cases it is easily inferrable also seems odd.

This does a simple inferring of the class name for an association based
on the association name.

I think this simple enough to still be "mini". If we don't want to add
this, though, we probably *shouldn't* define the setter & getter methods
when the `class_name` option isn't provided.

cc @codeclimate/review