### PR TITLE
Set updated_at in relevant setter methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+* Updated `updated_at` when enabled from all setter methods. ([@wfleming][])
+
 ### Changes
 
 ## v1.0.0 (2016-10-27)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ things as simple as possible.
 
 * Interact with Ruby objects instead of hashes
 * Full access to the powerful MongoDB client
-* Thread safe. (Hopefully)
-* Simple and easily extensible (Less than 500 lines of code.)
+* Thread safe (hopefully)
+* Simple and easily extensible
 * ActiveModel-compatible
 * Validations
 * Timestamp tracking (created_at/updated_at)

--- a/lib/minidoc/timestamps.rb
+++ b/lib/minidoc/timestamps.rb
@@ -15,6 +15,28 @@ module Minidoc::Timestamps
     end
   end
 
+  def set(attributes)
+    if self.class.record_timestamps
+      super(attributes.merge(updated_at: Time.now.utc))
+    else
+      super(attributes)
+    end
+  end
+
+  def atomic_set(query, attributes)
+    if self.class.record_timestamps
+      super(query, attributes.merge(updated_at: Time.now.utc))
+    else
+      super(query, attributes)
+    end
+  end
+
+  def unset(*keys)
+    super
+
+    set(updated_at: Time.now.utc) if self.class.record_timestamps
+  end
+
 private
 
   def create

--- a/spec/minidoc/timestamps_spec.rb
+++ b/spec/minidoc/timestamps_spec.rb
@@ -4,6 +4,8 @@ describe Minidoc::Timestamps do
   class TimestampsUser < Minidoc
     include Minidoc::Timestamps
 
+    attribute :name, String
+
     timestamps!
   end
 
@@ -18,6 +20,28 @@ describe Minidoc::Timestamps do
       user = TimestampsUser.create
       sleep 0.001
       user.save
+      expect(user.created_at).to_not eq user.updated_at
+    end
+
+    it "updates updated_at when doc is changed with #set" do
+      user = TimestampsUser.create
+      sleep 0.001
+      user.set(name: "Abby Normal")
+      expect(user.created_at).to_not eq user.updated_at
+    end
+
+    it "updates updated_at when doc is changed with #atomic_set" do
+      user = TimestampsUser.create
+      sleep 0.001
+      user.atomic_set({ name: nil }, name: "Abby Normal")
+      expect(user.created_at).to_not eq user.updated_at
+    end
+
+    it "updates updated_at when doc is changed with #unset" do
+      user = TimestampsUser.create(name: "Abby Normal")
+      sleep 0.001
+      user.unset(:name)
+      expect(user.name).to be_nil
       expect(user.created_at).to_not eq user.updated_at
     end
   end


### PR DESCRIPTION
`#set`, `#atomic_set`, and `#unset` don't update `#updated_at` when
timestamps are enabled for the class. This updates these methods in the
`Timestamps` module so that they will also set this field when
appropriate.

cc @codeclimate/review
