### PR TITLE
Rm Minidoc.transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changes
 
+* Removed transaction support. ([@wfleming][])
+
 ## v1.0.1 (2016-10-31)
 
 ### Bug fixes


### PR DESCRIPTION
Transaction support was limited to TokuMX, which we're migrating away from.
Using it on some Mongo variants but not others was a source of occasional
confusion & bugs: we've stopped relying on it, and keeping the API when it's
likely to be a no-op in most environments makes it more likely to provide
false assurance than anything else. So it's time for it to go.