### PR TITLE
Add raising association methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+* Association methods that raise when the document is not found ([@pbrisbin][])
+
 ### Bug fixes
 
 ### Changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2-slim
+
+RUN apt-get update && apt-get install -y build-essential
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY Gemfile .
+COPY minidoc.gemspec .
+
+RUN mkdir -p lib/minidoc
+COPY lib/minidoc/version.rb lib/minidoc/version.rb
+
+RUN bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "bson_ext"
 gem "codeclimate-test-reporter", "~> 1.0.0"
 gem "rake"
 gem "rspec"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: image test
+
+DOCKER_RUN ?= docker run --rm
+MONGODB_URI ?= mongodb://mongodb/minidoc_test
+
+image:
+	docker build -t codeclimate/minidoc .
+
+test: image
+	$(DOCKER_RUN) \
+	  --env MONGODB_URI="$(MONGODB_URI)" \
+	  --volume "$(PWD)":/app \
+	  codeclimate/minidoc bundle exec rspec $(RSPEC_ARGS)

--- a/README.md
+++ b/README.md
@@ -122,6 +122,17 @@ drink = Drink.create(name: "Paloma", user: bryan)
 drink.user == bryan #=> true
 ```
 
+Associations are also exposed as "bang methods" which raise a
+`Minidoc::DocumentNotFoundError` if the record pointed to by the foreign key is
+no longer present. (This can be useful in web frameworks where such exceptions
+automatically result in 404 responses.)
+
+```rb
+user.destroy
+Drink.find(name: "Paloma").user!
+# => Minidoc::DocumentNotFoundError
+```
+
 ### Read-only records
 
 ```ruby

--- a/lib/minidoc/associations.rb
+++ b/lib/minidoc/associations.rb
@@ -28,6 +28,11 @@ module Minidoc::Associations
       define_method(association_name) do
         read_association(association_name)
       end
+
+      define_method("#{association_name}!") do
+        read_association(association_name) or
+          raise Minidoc::DocumentNotFoundError
+      end
     end
   end
 

--- a/minidoc.gemspec
+++ b/minidoc.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/codeclimate/minidoc"
   spec.license = "MIT"
 
-  spec.files = `git ls-files`.split($/)
-  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.files = Dir["lib/**/*.rb"] + Dir["spec/**/*.rb"]
+  spec.executables = []
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 

--- a/spec/minidoc/associations_spec.rb
+++ b/spec/minidoc/associations_spec.rb
@@ -30,8 +30,16 @@ describe Minidoc::Associations do
       user = User.create
       cat = Cat.new(owner_id: user.id)
       expect(cat.owner.id).to eq user.id
+      expect(cat.owner!.id).to eq user.id
       cat.save
       expect(cat.owner.id).to eq user.id
+      expect(cat.owner!.id).to eq user.id
+    end
+
+    it "defines methods that raise when not found" do
+      cat = Cat.new
+      cat.owner_id = BSON::ObjectId.new
+      expect { cat.owner! }.to raise_error(Minidoc::DocumentNotFoundError)
     end
 
     it "caches the association cache rather than go to the database each time" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,9 +22,9 @@ class SecondUser < Minidoc
   attribute :age, Integer
 end
 
-$mongo = Mongo::MongoClient.from_uri(ENV["MONGODB_URI"] || "mongodb://localhost")
+$mongo = Mongo::MongoClient.from_uri(ENV["MONGODB_URI"] || "mongodb://localhost/minidoc_test")
 Minidoc.connection = $mongo
-Minidoc.database_name = "minidoc_test"
+Minidoc.database_name = $mongo.db.name
 
 RSpec.configure do |config|
   if config.files_to_run.one?


### PR DESCRIPTION
This is most useful in our typical resource authorization pattern:

```rb
post = Post.find(author_id: x, id: y)

authorize! { post.author.viewable_by?(current_user) }
```

Using this pattern loses automatic 404 behavior when the author with `id:x`
doesn't exist. With this change, we can now do:

```rb
post = Post.find(author_id: x, id: y)

authorize! { post.author!.viewable_by?(current_user) }
```