### PR TITLE
 Fix Minidoc::ReadOnly connection inheritance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,7 @@ Style/DotPosition:
 # Common globals we allow
 Style/GlobalVars:
   AllowedVariables:
+  - "$alt_mongo"
   - "$statsd"
   - "$mongo"
   - "$rollout"

--- a/lib/minidoc/read_only.rb
+++ b/lib/minidoc/read_only.rb
@@ -5,7 +5,14 @@ class Minidoc::ReadOnly < Minidoc::Value
   include Minidoc::Connection
   include Minidoc::Finders
 
-  def self.database
-    Minidoc.database
+  # This and `self.database_name` are deleted & redefined by `class_attribute`
+  # when you call `.connection=` or `.database_name=`, so these still allow
+  # `ReadOnly` subclasses to override their connection details
+  def self.connection
+    Minidoc.connection
+  end
+
+  def self.database_name
+    Minidoc.database_name
   end
 end

--- a/lib/minidoc/test_helpers.rb
+++ b/lib/minidoc/test_helpers.rb
@@ -16,9 +16,11 @@ class Minidoc
     end
 
     def each_collection(&block)
-      Minidoc.database.collections.
-        reject { |c| c.name.include?("system") }.
-        each(&block)
+      [$mongo, $alt_mongo].each do |conn|
+        conn.db.collections.
+          reject { |c| c.name.include?("system") }.
+          each(&block)
+      end
     end
   end
 end

--- a/spec/minidoc/read_only_spec.rb
+++ b/spec/minidoc/read_only_spec.rb
@@ -6,6 +6,13 @@ describe Minidoc::ReadOnly do
     attribute :name, String
   end
 
+  class AltModel < Minidoc::ReadOnly
+    self.connection = $alt_mongo
+    self.database_name = $alt_mongo.db.name
+
+    attribute :name, String
+  end
+
   it "is read only, meaning it can't change over time" do
     expect { ReadOnlyUser.create(name: "Bryan") }.to raise_error(NoMethodError)
 
@@ -16,6 +23,17 @@ describe Minidoc::ReadOnly do
     expect(user).to eq user.as_value
 
     expect { user.name = "Noah" }.to raise_error(NoMethodError)
+  end
+
+  it "can have a separate mongo connection" do
+    expect(AltModel.count).to eq(0)
+    $alt_mongo.db[:alt_models].insert(name: "42")
+    expect(AltModel.count).to eq(1)
+
+    instance = AltModel.find_one(name: "42")
+    expect(instance.name).to eq("42")
+
+    expect { instance.name = "Noah" }.to raise_error(NoMethodError)
   end
 
   it "can become a value object" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,9 @@ $mongo = Mongo::MongoClient.from_uri(ENV["MONGODB_URI"] || "mongodb://localhost/
 Minidoc.connection = $mongo
 Minidoc.database_name = $mongo.db.name
 
+alt_url = "mongodb://#{$mongo.host}/#{$mongo.db.name}_2"
+$alt_mongo = Mongo::MongoClient.from_uri(alt_url)
+
 RSpec.configure do |config|
   if config.files_to_run.one?
     config.default_formatter = "doc"


### PR DESCRIPTION
The previous implementation effectively presumed all minidoc subclasses
are using one connection/database, which we aren't doing anymore.

This fixes these methods to support overriding these attributes on read
only classes, same as normal Minidoc clases.