### PR TITLE
Install ruby-dev in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2-slim
 
-RUN apt-get update && apt-get install -y build-essential
+RUN apt-get update && apt-get install -y build-essential ruby-dev
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
The `json` gem wants to build a C extension, it needs headers.