### PR TITLE
Use `simplecov`'s JSON formatter on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ citest:
 	docker run \
 		--network minidoc \
 		--env MONGODB_URI="mongodb://mongodb/minidoc_test" \
+		--env CI="true" \
 		--name "minidoc-${CIRCLE_WORKFLOW_ID}" \
 	  codeclimate/minidoc bundle exec rspec
 	docker cp "minidoc-${CIRCLE_WORKFLOW_ID}":/app/coverage ./coverage

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,10 @@
 require "simplecov"
+
+if ENV["CI"]
+  require "simplecov_json_formatter"
+  SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
+end
+
 SimpleCov.start do
   add_filter "/test/"
 end


### PR DESCRIPTION
More recent versions of our test-reporter tool needs for `simplecov` to report coverage data as `JSON`.
