### PR TITLE
Upgrade mongo dependency and refactor code to support mongo v2.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Changes
 
+## 3.0.0 (2023-04-06)
+
+## Changes
+* Upgrade `mongo` dependency to support version `2.14.1`
 ## v2.1.0 (2019-05-10)
 
 ### Changes

--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,17 @@ mongodb-test-server:
 		--name mongodb \
 		circleci/mongo:3.2
 
-test: image
-	$(DOCKER_RUN) \
+test:
+	$(DOCKER_RUN) -it \
 		--network minidoc \
 	  --env MONGODB_URI="$(MONGODB_URI)" \
+	  --volume "$(PWD)":/app \
 	  codeclimate/minidoc bundle exec rspec $(RSPEC_ARGS)
 
 citest:
 	docker run \
 		--network minidoc \
 		--env MONGODB_URI="mongodb://mongodb/minidoc_test" \
-		--env CI="true" \
 		--name "minidoc-${CIRCLE_WORKFLOW_ID}" \
 	  codeclimate/minidoc bundle exec rspec
 	docker cp "minidoc-${CIRCLE_WORKFLOW_ID}":/app/coverage ./coverage
@@ -35,3 +35,8 @@ irb: image
 	  --env MONGODB_URI="$(MONGODB_URI)" \
 	  --volume "$(PWD)":/app \
 	  codeclimate/minidoc irb -I lib -r minidoc
+
+bundle:
+	$(DOCKER_RUN) \
+	  --volume "$(PWD)":/app \
+	  codeclimate/minidoc bundle $(BUNDLE_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ citest:
 	docker run \
 		--network minidoc \
 		--env MONGODB_URI="mongodb://mongodb/minidoc_test" \
+		--env CI="true" \
 		--name "minidoc-${CIRCLE_WORKFLOW_ID}" \
 	  codeclimate/minidoc bundle exec rspec
 	docker cp "minidoc-${CIRCLE_WORKFLOW_ID}":/app/coverage ./coverage

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ gem install minidoc
 ### Setup
 
 ```ruby
-Minidoc.connection = Mongo::MongoClient.from_uri("mongodb://localhost")
+Minidoc.connection = Mongo::Client.new("mongodb://localhost")
 Minidoc.database_name = "my_great_app_development"
 ```
 

--- a/lib/minidoc/connection.rb
+++ b/lib/minidoc/connection.rb
@@ -12,12 +12,13 @@ module Minidoc::Connection
 
   module ClassMethods
     def collection
-      database[collection_name]
+      validate_config
+      connection.use(database_name)
+      connection[collection_name]
     end
 
     def database
-      validate_config
-      connection[database_name]
+      connection.use(database_name).database
     end
 
     def collection_name=(name)

--- a/lib/minidoc/counters.rb
+++ b/lib/minidoc/counters.rb
@@ -27,10 +27,10 @@ class Minidoc
       end
 
       def increment(step_size = 1)
-        result = record.class.collection.find_and_modify(
-          query: { _id: record.id },
-          update: { "$inc" => { field => step_size } },
-          new: true,
+        result = record.class.collection.find_one_and_update(
+          { _id: record.id },
+          { "$inc" => { field => step_size } },
+          return_document: :after,
         )
 
         result[field.to_s]

--- a/lib/minidoc/duplicate_key.rb
+++ b/lib/minidoc/duplicate_key.rb
@@ -1,12 +1,11 @@
-class Minidoc::DuplicateKey < Mongo::OperationFailure
-  DUPLICATE_KEY_ERROR_CODE = 11000
+class Minidoc::DuplicateKey < StandardError
+  DUPLICATE_KEY_ERROR_CODE = "E11000".freeze
 
-  def self.duplicate_key_exception(exception)
-    if exception.respond_to?(:error_code) && exception.error_code == DUPLICATE_KEY_ERROR_CODE
-      new(exception.message, exception.error_code, exception.result)
+  def self.duplicate_key_exception(ex)
+    if ex.is_a?(Mongo::Error::OperationFailure) && ex.message.starts_with?(DUPLICATE_KEY_ERROR_CODE)
+      new(ex.message)
     else
       nil
     end
   end
-
 end

--- a/lib/minidoc/finders.rb
+++ b/lib/minidoc/finders.rb
@@ -60,15 +60,13 @@ module Minidoc::Finders
     end
 
     def wrapper
-      @wrapper ||= Proc.new do |doc|
+      @wrapper ||= proc do |doc|
         if doc
           if doc.is_a?(Array) || doc.is_a?(Mongo::Cursor)
             doc.map { |d| from_db(d) }
           else
             from_db(doc)
           end
-        else
-          nil
         end
       end
     end
@@ -82,13 +80,13 @@ module Minidoc::Finders
       @doc_wrapper = doc_wrapper
     end
 
-    def each(&block)
+    def each(&_block)
       if block_given?
         @view.each do |doc|
-          yield  @doc_wrapper.call(doc)
+          yield @doc_wrapper.call(doc)
         end
       else
-       to_enum
+        to_enum
       end
     end
 

--- a/lib/minidoc/grid.rb
+++ b/lib/minidoc/grid.rb
@@ -1,7 +1,18 @@
-class Minidoc::Grid < Mongo::Grid
+class Minidoc::Grid
+  def initialize(database)
+    @bucket = Mongo::Grid::FSBucket.new(database)
+  end
+
+  def put(str, filename = SecureRandom.uuid)
+    bucket.upload_from_stream(filename, StringIO.new(str))
+  end
+
   def get(id)
     id = BSON::ObjectId(id.to_s)
-    super(id)
+    io = StringIO.new
+    bucket.download_to_stream(id, io)
+    io.rewind
+    io
   end
 
   def get_json(id)
@@ -11,6 +22,10 @@ class Minidoc::Grid < Mongo::Grid
 
   def delete(id)
     id = BSON::ObjectId(id.to_s)
-    super(id)
+    bucket.delete(id)
   end
+
+  private
+
+  attr_reader :bucket
 end

--- a/lib/minidoc/test_helpers.rb
+++ b/lib/minidoc/test_helpers.rb
@@ -12,7 +12,7 @@ class Minidoc
     end
 
     def clear_collections(connection = Minidoc.connection)
-      each_collection(connection) { |c| c.remove({}) }
+      each_collection(connection, &:drop)
     end
 
     def clear_indexes(connection = Minidoc.connection)
@@ -20,7 +20,7 @@ class Minidoc
     end
 
     def each_collection(connection, &block)
-      connection.db.collections.
+      connection.collections.
         reject { |c| c.name.include?("system") }.
         each(&block)
     end

--- a/lib/minidoc/version.rb
+++ b/lib/minidoc/version.rb
@@ -1,3 +1,3 @@
 class Minidoc
-  VERSION = "2.1.0".freeze
+  VERSION = "3.0.0".freeze
 end

--- a/minidoc.gemspec
+++ b/minidoc.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activemodel", ">= 3.0.0", "< 6"
   spec.add_dependency "activesupport", ">= 3.0.0", "< 6"
+  spec.add_dependency "activemodel", ">= 3.0.0", "< 6"
   spec.add_dependency "virtus", "~> 1.0", ">= 1.0.0"
-  spec.add_dependency "mongo", "~> 1"
+  spec.add_dependency "mongo", "~> 2.14", "<= 2.14.1"
 end

--- a/minidoc.gemspec
+++ b/minidoc.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 3.0.0", "< 6"
   spec.add_dependency "activemodel", ">= 3.0.0", "< 6"
-  spec.add_dependency "virtus", "~> 1.0", ">= 1.0.0"
+  spec.add_dependency "activesupport", ">= 3.0.0", "< 6"
   spec.add_dependency "mongo", "~> 2.14", "<= 2.14.1"
+  spec.add_dependency "virtus", "~> 1.0", ">= 1.0.0"
 end

--- a/spec/minidoc/connection_spec.rb
+++ b/spec/minidoc/connection_spec.rb
@@ -29,7 +29,7 @@ describe "connection" do
 
   describe ".database" do
     it "exposes the underlying Mongo object" do
-      expect(User.database).to be_a Mongo::DB
+      expect(User.database).to be_a Mongo::Database
     end
 
     it "passes through the database name to the underlying Mongo::DB" do

--- a/spec/minidoc/finders_spec.rb
+++ b/spec/minidoc/finders_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 describe Minidoc::Finders do
   describe ".all" do
     it "returns all of the documents in the collection" do
-      (User.collection << { name: "Joe" })
-      (User.collection << { name: "Bryan" })
+      User.collection.insert_one(name: "Joe")
+      User.collection.insert_one(name: "Bryan")
       users = User.all
       expect(["Bryan", "Joe"]).to match_array(users.map(&:name))
     end
@@ -12,21 +12,21 @@ describe Minidoc::Finders do
 
   describe ".count" do
     it "counts the documents in the collection" do
-      (User.collection << { name: "Joe" })
-      (User.collection << { name: "Bryan" })
+      User.collection.insert_one(name: "Joe")
+      User.collection.insert_one(name: "Bryan")
       expect(User.count).to eq 2
     end
 
     it "can be scoped by a query" do
-      (User.collection << { name: "Joe" })
-      (User.collection << { name: "Bryan" })
+      User.collection.insert_one(name: "Joe")
+      User.collection.insert_one(name: "Bryan")
       expect(User.count(name: "Bryan")).to eq 1
     end
   end
 
   describe ".exists?" do
     it "tells you if any documents exist that match a query" do
-      (User.collection << { name: "Joe" })
+      User.collection.insert_one(name: "Joe")
       expect(User.exists?(name: "Joe")).to be(true)
       expect(User.exists?(name: "Bryan")).to be(false)
     end

--- a/spec/minidoc/grid_spec.rb
+++ b/spec/minidoc/grid_spec.rb
@@ -10,7 +10,6 @@ describe Minidoc::Grid do
 
       document = grid.get doc_id.to_s
 
-      expect(document).to be_a Mongo::GridIO
       expect(document.read).to eq "estamos en espana"
     end
   end
@@ -30,9 +29,9 @@ describe Minidoc::Grid do
     it "removes the 'file' from the database" do
       doc_id = grid.put "estamos en espana"
 
+      expect(grid.get(doc_id).read).to eq("estamos en espana")
       grid.delete doc_id.to_s
-
-      expect { grid.get doc_id }.to raise_error(Mongo::GridFileNotFound)
+      expect { grid.get(doc_id) }.to raise_error(Mongo::Error::FileNotFound)
     end
   end
 end

--- a/spec/minidoc/read_only_spec.rb
+++ b/spec/minidoc/read_only_spec.rb
@@ -3,12 +3,15 @@ require "spec_helper"
 describe Minidoc::ReadOnly do
   class ReadOnlyUser < Minidoc::ReadOnly
     self.collection_name = "users"
+    self.database_name = "minidoc_test"
+    self.connection = $mongo
+
     attribute :name, String
   end
 
   class AltModel < Minidoc::ReadOnly
     self.connection = $alt_mongo
-    self.database_name = $alt_mongo.db.name
+    self.database_name = $alt_mongo.database.name
 
     attribute :name, String
   end
@@ -27,7 +30,7 @@ describe Minidoc::ReadOnly do
 
   it "can have a separate mongo connection" do
     expect(AltModel.count).to eq(0)
-    $alt_mongo.db[:alt_models].insert(name: "42")
+    $alt_mongo.database[:alt_models].insert_one(name: "42")
     expect(AltModel.count).to eq(1)
 
     instance = AltModel.find_one(name: "42")

--- a/spec/minidoc_spec.rb
+++ b/spec/minidoc_spec.rb
@@ -95,7 +95,7 @@ describe Minidoc do
     it "raises Minidoc::DuplicateKey where appropriate" do
       collection = double
       expect(User).to receive(:collection).and_return(collection)
-      expect(collection).to receive(:<<).and_raise(Mongo::OperationFailure.new("Duplicate key exception", Minidoc::DuplicateKey::DUPLICATE_KEY_ERROR_CODE))
+      expect(collection).to receive(:insert_one).and_raise(Mongo::Error::OperationFailure.new("E11000 Boooo"))
       user = User.new
 
       expect { user.save }.to raise_error(Minidoc::DuplicateKey)
@@ -104,7 +104,7 @@ describe Minidoc do
     it "doesn't suppress errors it shouldn't" do
       collection = double
       expect(User).to receive(:collection).and_return(collection)
-      expect(collection).to receive(:<<).and_raise(ArgumentError)
+      expect(collection).to receive(:insert_one).and_raise(ArgumentError)
       user = User.new
 
       expect { user.save }.to raise_error(ArgumentError)
@@ -260,7 +260,7 @@ describe Minidoc do
       user = User.create!(name: "Bryan")
       expect(user.reload.name).to eq "Bryan"
 
-      User.collection.update({ :_id => user.id }, name: "Noah")
+      User.collection.update_one({ :_id => user.id }, name: "Noah")
       expect(user.name).to eq "Bryan"
 
       user.reload

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require "simplecov"
+require "simplecov_json_formatter"
+SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
 SimpleCov.start do
   add_filter "/test/"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
 require "simplecov"
-require "simplecov_json_formatter"
-SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
+
+if ENV["CI"]
+  require "simplecov_json_formatter"
+  SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
+end
+
 SimpleCov.start do
   add_filter "/test/"
 end


### PR DESCRIPTION
This commit updates the mongo dependency to version 2.14.1 and makes necessary changes in the codebase to support this version. The changes include refactoring method calls, error handling, and using new MongoDB driver classes. The minidoc version is also bumped to 3.0.0.